### PR TITLE
Add LateResource union

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! - [MSP430](https://crates.io/crates/msp430-rtfm)
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(optin_builtin_traits)]
+#![feature(optin_builtin_traits, untagged_unions)]
 #![no_std]
 
 extern crate static_ref;
@@ -80,6 +80,15 @@ where
     {
         f(self, t)
     }
+}
+
+/// A resource initialized by `init`.
+#[allow(unions_with_drop_fields)]
+pub union LateResource<T> {
+    /// Uninitialized state before and during `init`.
+    pub uninit: (),
+    /// Initialized state after `init` was run.
+    pub init: T,
 }
 
 /// Preemption threshold token

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! - [MSP430](https://crates.io/crates/msp430-rtfm)
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(optin_builtin_traits, untagged_unions)]
+#![feature(optin_builtin_traits)]
 #![no_std]
 
 extern crate static_ref;
@@ -84,7 +84,7 @@ where
 
 /// A resource initialized by `init`.
 #[allow(unions_with_drop_fields)]
-pub union LateResource<T> {
+pub union LateResource<T: Copy> {
     /// Uninitialized state before and during `init`.
     pub uninit: (),
     /// Initialized state after `init` was run.


### PR DESCRIPTION
This union will be used to implement https://github.com/japaric/cortex-m-rtfm/issues/37 in https://github.com/japaric/cortex-m-rtfm/pull/43

~~Sadly, this requires using the `untagged_unions` feature flag since `T` may not be `Copy` ("unions with non-`Copy` fields are unstable"). See https://github.com/rust-lang/rust/issues/32836. We might get away with requiring `T: Copy`, now that I think about it.~~ (I have added the `T: Copy` bound)