### PR TITLE
Use embedded-time for Clock/Instant/Duration implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+-  Common parts from `cortex-m-rfm` has been moved here
+
+### Changed
+
+- [breaking-change] The `Mutex` trait has been removed in favor of `mutex-trait` crate
+
 ## [v0.3.0] - 2019-11-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,8 @@ keywords = []
 license = "MIT OR Apache-2.0"
 name = "rtfm-core"
 repository = "https://github.com/rtfm-rs/rtfm-core"
-version = "0.3.0"
+version = "0.4.0"
+edition = "2018"
+
+[dependencies]
+mutex-trait = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ edition = "2018"
 
 [dependencies]
 mutex-trait = "0.2.0"
+embedded-time = { git = "https://github.com/PTaylor-FluenTech/embedded-time", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ version = "0.4.0"
 edition = "2018"
 
 [dependencies]
-mutex-trait = "0.1.0"
+mutex-trait = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,23 +16,10 @@
 #![no_std]
 
 pub use mutex_trait::{prelude::*, Exclusive, Mutex};
-pub use embedded_time;
-
-/// A fraction
-pub struct Fraction {
-    /// The numerator
-    pub numerator: u32,
-
-    /// The denominator
-    pub denominator: u32,
-}
+pub use embedded_time as time;
 
 /// A monotonic clock / counter
-pub trait Monotonic: embedded_time::Clock {
-    // /// A measurement of this clock, use `CYCCNT` as a reference implementation for `Instant`.
-    // /// Note that the Instant must be a signed value such as `i32`.
-    // type Instant;
-
+pub trait Monotonic: time::Clock {
     /// Resets the counter to *zero*
     ///
     /// # Safety
@@ -41,9 +28,6 @@ pub trait Monotonic: embedded_time::Clock {
     /// before tasks can start; this is also the case in multi-core applications. User code must
     /// *never* call this function.
     unsafe fn reset();
-
-    // /// A `Self::Instant` that represents a count of *zero*
-    // fn zero() -> Self::Instant;
 }
 
 /// A marker trait that indicates that it is correct to use this type in multi-core context

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@
 #![deny(warnings)]
 #![no_std]
 
-use core::ops::Sub;
 pub use mutex_trait::{prelude::*, Exclusive, Mutex};
+pub use embedded_time;
 
 /// A fraction
 pub struct Fraction {
@@ -28,26 +28,10 @@ pub struct Fraction {
 }
 
 /// A monotonic clock / counter
-pub trait Monotonic {
-    /// A measurement of this clock, use `CYCCNT` as a reference implementation for `Instant`.
-    /// Note that the Instant must be a signed value such as `i32`.
-    type Instant: Copy + Ord + Sub;
-
-    /// The ratio between the system timer (SysTick) frequency and this clock frequency, i.e.
-    /// `Monotonic clock * Fraction = System clock`
-    ///
-    /// The ratio must be expressed in *reduced* `Fraction` form to prevent overflows. That is
-    /// `2 / 3` instead of `4 / 6`
-    fn ratio() -> Fraction;
-
-    /// Returns the current time
-    ///
-    /// # Correctness
-    ///
-    /// This function is *allowed* to return nonsensical values if called before `reset` is invoked
-    /// by the runtime. Therefore application authors should *not* call this function during the
-    /// `#[init]` phase.
-    fn now() -> Self::Instant;
+pub trait Monotonic: embedded_time::Clock {
+    // /// A measurement of this clock, use `CYCCNT` as a reference implementation for `Instant`.
+    // /// Note that the Instant must be a signed value such as `i32`.
+    // type Instant;
 
     /// Resets the counter to *zero*
     ///
@@ -58,8 +42,8 @@ pub trait Monotonic {
     /// *never* call this function.
     unsafe fn reset();
 
-    /// A `Self::Instant` that represents a count of *zero*
-    fn zero() -> Self::Instant;
+    // /// A `Self::Instant` that represents a count of *zero*
+    // fn zero() -> Self::Instant;
 }
 
 /// A marker trait that indicates that it is correct to use this type in multi-core context


### PR DESCRIPTION
This is a companion PR to rtfm-rs/cortex-m-rtfm#312.